### PR TITLE
🛠️ fix: normalize Responses tool continuation payloads and gate native search tools

### DIFF
--- a/src/agent/grok-agent.ts
+++ b/src/agent/grok-agent.ts
@@ -127,11 +127,10 @@ You have access to these tools:
 - search: Unified search tool for finding text content or files (similar to Cursor's search functionality)
 - create_todo_list: Create a visual todo list for planning and tracking tasks
 - update_todo_list: Update existing todos in your todo list
-- web_search: Perform a web search to find up-to-date information, news, and facts from the internet
-- x_search: Search the X platform (formerly Twitter) for latest trends and real-time posts
+- web_search / x_search: Built-in internet and X search when supported by the current model
  
 REAL-TIME INFORMATION:
-You have access to real-time information via the built-in search tools (web_search and x_search). When users ask for current information, latest news, or recent events, use these tools to find the most accurate and up-to-date information.
+When the current model supports built-in search tools, you can use web_search and x_search to find current information, latest news, and recent events.
 
 
 IMPORTANT TOOL USAGE RULES:

--- a/src/grok/client.test.ts
+++ b/src/grok/client.test.ts
@@ -1,0 +1,155 @@
+import { Readable } from "node:stream";
+import axios from "axios";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GrokClient } from "./client.js";
+
+describe("GrokClient", () => {
+  beforeEach(() => {
+    delete process.env.GROK_DISABLE_NATIVE_SEARCH;
+    delete process.env.GROK_FORCE_NATIVE_SEARCH;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("sends all trailing tool outputs as function_call_output items", async () => {
+    const postSpy = vi.spyOn(axios, "post").mockResolvedValue({
+      data: {
+        id: "resp_next",
+        output: [
+          {
+            type: "message",
+            content: [{ type: "output_text", text: "ok" }],
+          },
+        ],
+      },
+    } as any);
+
+    const client = new GrokClient("dummy", "grok-code-fast-1") as any;
+    client.lastResponseId = "resp_prev";
+
+    await client.chat(
+      [
+        { role: "system", content: "sys" },
+        { role: "user", content: "hello" },
+        { role: "assistant", content: "", tool_calls: [] },
+        { role: "tool", tool_call_id: "call_1", content: "FIRST" },
+        { role: "tool", tool_call_id: "call_2", content: "SECOND" },
+      ] as any,
+      [
+        {
+          type: "web_search",
+        },
+        {
+          type: "x_search",
+        },
+        {
+          type: "function",
+          function: {
+            name: "view_file",
+            description: "View a file",
+            parameters: {
+              type: "object",
+              properties: {},
+              required: [],
+            },
+          },
+        },
+      ] as any
+    );
+
+    const [, payload] = postSpy.mock.calls[0] as [string, any];
+    expect(payload.model).toBe("grok-code-fast-1");
+    expect(payload.previous_response_id).toBe("resp_prev");
+    expect(payload.input).toEqual([
+      {
+        type: "function_call_output",
+        call_id: "call_1",
+        output: "FIRST",
+      },
+      {
+        type: "function_call_output",
+        call_id: "call_2",
+        output: "SECOND",
+      },
+    ]);
+    expect(payload.tools).toEqual([
+      {
+        type: "function",
+        name: "view_file",
+        description: "View a file",
+        parameters: {
+          type: "object",
+          properties: {},
+          required: [],
+        },
+      },
+    ]);
+  });
+
+  it("uses a Grok 4 model for built-in search when the current model does not support it", async () => {
+    const postSpy = vi.spyOn(axios, "post").mockResolvedValue({
+      data: {
+        id: "resp_search",
+        output: [
+          {
+            type: "message",
+            content: [{ type: "output_text", text: "search result" }],
+          },
+        ],
+      },
+    } as any);
+
+    const client = new GrokClient("dummy", "grok-3-fast");
+    await client.search("latest xAI news");
+
+    const [, payload] = postSpy.mock.calls[0] as [string, any];
+    expect(payload.model).toBe("grok-4-1-fast-reasoning");
+    expect(payload.tools).toEqual([{ type: "web_search" }, { type: "x_search" }]);
+  });
+
+  it("normalizes continuation payloads in chatStream as well", async () => {
+    const postSpy = vi.spyOn(axios, "post").mockResolvedValue({
+      data: Readable.from([
+        'data: {"id":"resp_stream","type":"response.output_text.delta","delta":"hel"}\n',
+        'data: {"type":"response.output_text.delta","delta":"lo"}\n',
+        "data: [DONE]\n",
+      ]),
+    } as any);
+
+    const client = new GrokClient("dummy", "grok-code-fast-1") as any;
+    client.lastResponseId = "resp_prev";
+
+    const chunks: string[] = [];
+    for await (const chunk of client.chatStream(
+      [
+        { role: "assistant", content: "", tool_calls: [] },
+        { role: "tool", tool_call_id: "call_stream_1", content: "ONE" },
+        { role: "tool", tool_call_id: "call_stream_2", content: "TWO" },
+      ] as any,
+      [{ type: "web_search" }] as any
+    )) {
+      const content = chunk.choices?.[0]?.delta?.content;
+      if (content) {
+        chunks.push(content);
+      }
+    }
+
+    const [, payload] = postSpy.mock.calls[0] as [string, any];
+    expect(payload.input).toEqual([
+      {
+        type: "function_call_output",
+        call_id: "call_stream_1",
+        output: "ONE",
+      },
+      {
+        type: "function_call_output",
+        call_id: "call_stream_2",
+        output: "TWO",
+      },
+    ]);
+    expect(payload.tools).toEqual([]);
+    expect(chunks.join("")).toBe("hello");
+  });
+});

--- a/src/grok/client.ts
+++ b/src/grok/client.ts
@@ -4,6 +4,8 @@ import type { ChatCompletionMessageParam } from "openai/resources/chat";
 
 export type GrokMessage = ChatCompletionMessageParam;
 
+const BUILT_IN_SEARCH_TOOL_TYPES = new Set(["web_search", "x_search"]);
+
 export type GrokTool = 
   | {
       type: "function";
@@ -42,6 +44,89 @@ export interface GrokResponse {
     };
     finish_reason: string;
   }>;
+}
+
+function supportsNativeSearchTools(model: string | undefined): boolean {
+  const normalizedModel = (model || "").toLowerCase();
+
+  if (process.env.GROK_DISABLE_NATIVE_SEARCH === "1") {
+    return false;
+  }
+
+  if (process.env.GROK_FORCE_NATIVE_SEARCH === "1") {
+    return true;
+  }
+
+  // xAI currently documents agentic search tooling against the Grok 4 family.
+  return normalizedModel.startsWith("grok-4");
+}
+
+function normalizeToolsForModel(
+  tools: GrokTool[] | undefined,
+  model: string
+): any[] {
+  return (tools || [])
+    .map((tool) => {
+      if (tool.type === "function") {
+        return {
+          type: "function",
+          name: tool.function.name,
+          description: tool.function.description,
+          parameters: tool.function.parameters,
+        };
+      }
+
+      if (
+        BUILT_IN_SEARCH_TOOL_TYPES.has(tool.type) &&
+        !supportsNativeSearchTools(model)
+      ) {
+        return null;
+      }
+
+      return tool;
+    })
+    .filter(Boolean);
+}
+
+function normalizeResponseInput(
+  messages: GrokMessage[],
+  lastResponseId: string | null
+): any[] {
+  if (!lastResponseId) {
+    return messages;
+  }
+
+  if (messages.length === 0) {
+    return [];
+  }
+
+  const trailingToolMessages: any[] = [];
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const message: any = messages[index];
+    if (message.role !== "tool") {
+      break;
+    }
+    trailingToolMessages.unshift(message);
+  }
+
+  if (trailingToolMessages.length > 0) {
+    return trailingToolMessages.map((message) => ({
+      type: "function_call_output",
+      call_id: message.tool_call_id,
+      output:
+        typeof message.content === "string"
+          ? message.content
+          : JSON.stringify(message.content ?? ""),
+    }));
+  }
+
+  const lastMessage: any = messages[messages.length - 1];
+  return [
+    {
+      role: lastMessage.role,
+      content: lastMessage.content ?? "",
+    },
+  ];
 }
 
 /**
@@ -110,47 +195,21 @@ export class GrokClient {
     model?: string
   ): Promise<GrokResponse> {
     try {
-      const toolPayload = (tools || []).map(t => {
-        if (t.type === "function") {
-          return {
-            type: "function",
-            name: t.function.name,
-            description: t.function.description,
-            parameters: t.function.parameters
-          };
-        }
-        return t;
-      });
+      const requestedModel = model || this.currentModel;
+      const toolPayload = normalizeToolsForModel(tools, requestedModel);
 
       // Reset state if we have a fresh conversation
       if (messages.length <= 2 && this.lastResponseId) {
         this.lastResponseId = null;
       }
 
-      const lastMessage = messages[messages.length - 1];
-      let input: any;
-
-      if (this.lastResponseId) {
-        // If continuing, only send the latest message
-        if (lastMessage.role === "tool") {
-          input = [{
-            role: "tool",
-            tool_call_id: lastMessage.tool_call_id,
-            content: lastMessage.content
-          }];
-        } else {
-          input = lastMessage.content;
-        }
-      } else {
-        // Starting fresh
-        input = messages;
-      }
+      const input = normalizeResponseInput(messages, this.lastResponseId);
 
       const payload: any = {
-        model: model || this.currentModel,
+        model: requestedModel,
         input,
         tools: toolPayload,
-        tool_choice: tools && tools.length > 0 ? "auto" : undefined,
+        tool_choice: toolPayload.length > 0 ? "auto" : undefined,
         temperature: 0.7,
         max_output_tokens: this.defaultMaxTokens,
         stream: false
@@ -233,47 +292,21 @@ export class GrokClient {
     model?: string
   ): AsyncGenerator<any, void, unknown> {
     try {
-      const toolPayload = (tools || []).map(t => {
-        if (t.type === "function") {
-          return {
-            type: "function",
-            name: t.function.name,
-            description: t.function.description,
-            parameters: t.function.parameters
-          };
-        }
-        return t;
-      });
+      const requestedModel = model || this.currentModel;
+      const toolPayload = normalizeToolsForModel(tools, requestedModel);
 
       // Reset state if we have a fresh conversation
       if (messages.length <= 2 && this.lastResponseId) {
         this.lastResponseId = null;
       }
 
-      const lastMessage = messages[messages.length - 1];
-      let input: any;
-
-      if (this.lastResponseId) {
-        // If continuing, only send the latest message
-        if (lastMessage.role === "tool") {
-          input = [{
-            role: "tool",
-            tool_call_id: lastMessage.tool_call_id,
-            content: lastMessage.content
-          }];
-        } else {
-          input = lastMessage.content;
-        }
-      } else {
-        // Starting fresh
-        input = messages;
-      }
+      const input = normalizeResponseInput(messages, this.lastResponseId);
 
       const payload: any = {
-        model: model || this.currentModel,
+        model: requestedModel,
         input,
         tools: toolPayload,
-        tool_choice: tools && tools.length > 0 ? "auto" : undefined,
+        tool_choice: toolPayload.length > 0 ? "auto" : undefined,
         temperature: 0.7,
         max_output_tokens: this.defaultMaxTokens,
         stream: true
@@ -361,6 +394,14 @@ export class GrokClient {
       content: query,
     };
 
-    return this.chat([searchMessage], [{ type: "web_search" }, { type: "x_search" }]);
+    const searchModel = supportsNativeSearchTools(this.currentModel)
+      ? this.currentModel
+      : "grok-4-1-fast-reasoning";
+
+    return this.chat(
+      [searchMessage],
+      [{ type: "web_search" }, { type: "x_search" }],
+      searchModel
+    );
   }
 }


### PR DESCRIPTION
## Summary

This PR fixes two related issues in the Responses API path:

1. Tool continuation requests were being sent in a Chat Completions style shape after `previous_response_id`, which could trigger `400` errors.
2. Built-in `web_search` / `x_search` tools were always included, even for models where native search support is not clearly available.

## What changed

- Normalize continuation input for `/v1/responses`
- Send trailing tool outputs as `function_call_output` items with `call_id` and `output`
- Preserve multiple trailing tool results instead of sending only the last one
- Gate built-in `web_search` / `x_search` for non-Grok-4 models
- Fall back to `grok-4-1-fast-reasoning` for `search()` when the current model should not use native search directly
- Update the system prompt copy so it no longer claims native search is always available
- Add tests covering:
  - non-streaming continuation payload normalization
  - streaming continuation payload normalization
  - native search fallback behavior

## Why this matters

The previous implementation could send invalid follow-up payloads after tool execution, especially when multiple tool calls were executed in one round. This made the Responses API flow fragile and likely caused `400` failures.

The change keeps the CLI aligned with the Responses API continuation model and avoids attaching native search tools to models that may not support them.

## Validation

I verified the following locally:

- `bun run build`
- `bun run typecheck`
- `bun test src/grok/client.test.ts`

I also ran an offline payload smoke test against the built `dist` output to confirm:
- multiple tool results are sent as `function_call_output`
- non-Grok-4 models do not automatically include native search tools
- the same normalization works in both `chat()` and `chatStream()`

## Manual verification

Manual verification on Windows PowerShell with the patched CLI produced a successful response:

```powershell
PS C:\Users\Aslan> grok -p "こんにちは"
{"role":"user","content":"こんにちは"}
{"role":"assistant","content":"こんにちは！ 何かお手伝いできることはありますか？ ファイル編集、コーディング、またはシステム操作のタスクをお知らせください。"}
